### PR TITLE
User Story: Create docker-compose.yaml for Multi-Container Setup

### DIFF
--- a/deploy/dev/.env
+++ b/deploy/dev/.env
@@ -1,0 +1,11 @@
+TRUSTED_PROXIES=123.123.123.123,123.123.123.124,123.123.123.125
+CORS_ORIGINS=http://localhost:4200
+CLIENT_URL=http://localhost:4200
+SESSION_SECRET=your-session-secret
+GMAIL_BATCH_SIZE=100
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_CALLBACK_URL=your-google-callback-url
+JWT_SECRET=your-jwt-secret
+MONGODB_URI=mongodb://mongo-user:mongo-password@server:27017/
+MONGODB_DB_NAME=gmail

--- a/deploy/dev/docker-compose.yaml
+++ b/deploy/dev/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   dev-api:
@@ -7,8 +7,19 @@ services:
     depends_on:
       - dev-mongo
     environment:
-      - MONGODB_URI=${MONGODB_URI}
+      - CLIENT_URL=${CLIENT_URL}
+      - CORS_ORIGINS=${CORS_ORIGINS}
+      - GMAIL_BATCH_SIZE=${GMAIL_BATCH_SIZE}
+      - GOOGLE_CALLBACK_URL=${GOOGLE_CALLBACK_URL}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - JWT_SECRET=${JWT_SECRET}
+      - LOKI_BASIC_AUTH=${LOKI_BASIC_AUTH}
+      - LOKI_HOST=${LOKI_HOST}
       - MONGODB_DB_NAME=${MONGODB_DB_NAME}
+      - MONGODB_URI=${MONGODB_URI}
+      - SESSION_SECRET=${SESSION_SECRET}
+      - TRUSTED_PROXIES=${TRUSTED_PROXIES}
 
   dev-client:
     container_name: dev-email-sweeperr-client

--- a/deploy/dev/docker-compose.yaml
+++ b/deploy/dev/docker-compose.yaml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  dev-api:
+    container_name: dev-email-sweeperr-api
+    image: ghcr.io/jtoniolo/email_sweeperr_api:dev
+    depends_on:
+      - dev-mongo
+    environment:
+      - MONGODB_URI=${MONGODB_URI}
+      - MONGODB_DB_NAME=${MONGODB_DB_NAME}
+
+  dev-client:
+    container_name: dev-email-sweeperr-client
+    image: ghcr.io/jtoniolo/email_sweeperr_client:dev
+    depends_on:
+      - dev-api
+    ports:
+      - "4200:4200"
+
+  dev-mongo:
+    container_name: dev-email-sweeperr-mongo
+    image: mongo:latest
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD}

--- a/src/.env.example
+++ b/src/.env.example
@@ -9,3 +9,5 @@ GOOGLE_CALLBACK_URL=your-google-callback-url
 JWT_SECRET=your-jwt-secret
 MONGODB_URI=mongodb://mongo-user:mongo-password@server:27017/
 MONGODB_DB_NAME=gmail
+LOKI_HOST=
+LOKI_BASIC_AUTH=

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,3 +1,4 @@
+API_URL=http://localhost:3000
 TRUSTED_PROXIES=123.123.123.123,123.123.123.124,123.123.123.125 # CSV list of trusted proxies' IPs
 CORS_ORIGINS=http://localhost:4200
 CLIENT_URL=http://localhost:4200

--- a/src/apps/ui/public/config.js
+++ b/src/apps/ui/public/config.js
@@ -1,0 +1,8 @@
+const { title } = require('process');
+
+const EmailSweeperr = EmailSweeperr || {};
+
+EmailSweeperr.config = {
+  title: 'Email Sweeperr',
+  apiBaseUrl: '',
+};

--- a/src/apps/ui/public/config.local.json
+++ b/src/apps/ui/public/config.local.json
@@ -1,3 +1,0 @@
-{
-  "apiBaseUrl": "http://localhost:3000"
-}

--- a/src/apps/ui/src/app/+state/app.effects.ts
+++ b/src/apps/ui/src/app/+state/app.effects.ts
@@ -14,10 +14,10 @@ export class AppEffects {
     this.actions$.pipe(
       ofType(AppActions.initApp),
       exhaustMap(() =>
-        this.appConfigService.loadAppConfig().pipe(
+        of(this.appConfigService.config).pipe(
           map((config: AppConfig) =>
             AppActions.loadAppSuccess({
-              app: { title: '' },
+              app: { ...config },
             })
           ),
           catchError((error) => of(AppActions.loadAppFailure({ error })))

--- a/src/apps/ui/src/app/+state/app.facade.spec.ts
+++ b/src/apps/ui/src/app/+state/app.facade.spec.ts
@@ -34,7 +34,7 @@ describe('AppFacade', () => {
   });
 
   it('allApp$ should select all app state', (done) => {
-    const expected: AppState = { loaded: true, title: '' };
+    const expected: AppState = { loaded: true, title: '', apiBaseUrl: '' };
     store.overrideSelector(AppSelectors.selectAllApp, expected);
 
     facade.allApp$.subscribe((allApp) => {

--- a/src/apps/ui/src/app/+state/app.models.ts
+++ b/src/apps/ui/src/app/+state/app.models.ts
@@ -3,5 +3,6 @@
  */
 export interface AppEntity {
   title: string;
+  apiBaseUrl: string;
   token?: string;
 }

--- a/src/apps/ui/src/app/+state/app.reducer.spec.ts
+++ b/src/apps/ui/src/app/+state/app.reducer.spec.ts
@@ -1,5 +1,4 @@
 import * as AppActions from './app.actions';
-import { AppEntity } from './app.models';
 import { AppState, initialAppState, appReducer } from './app.reducer';
 
 describe('App Reducer', () => {

--- a/src/apps/ui/src/app/+state/app.reducer.spec.ts
+++ b/src/apps/ui/src/app/+state/app.reducer.spec.ts
@@ -1,48 +1,58 @@
 import * as AppActions from './app.actions';
+import { AppEntity } from './app.models';
 import { AppState, initialAppState, appReducer } from './app.reducer';
 
 describe('App Reducer', () => {
-  describe('valid App actions', () => {
-    it('initApp should set loaded to false and clear error', () => {
+  describe('[App Page] Init action', () => {
+    it('should retrieve the app config and update the state in an immutable way', () => {
       const action = AppActions.initApp();
-      const result: AppState = appReducer(initialAppState, action);
-
-      expect(result.loaded).toBe(false);
-      expect(result.error).toBeNull();
-    });
-
-    it('loadAppSuccess should set loaded to true and update title', () => {
-      const app = { title: 'New Title' };
-      const action = AppActions.loadAppSuccess({ app });
-      const result: AppState = appReducer(initialAppState, action);
-
-      expect(result.loaded).toBe(true);
-      expect(result.title).toBe(app.title);
-    });
-
-    it('loadAppFailure should set error', () => {
-      const error = 'Error loading app';
-      const action = AppActions.loadAppFailure({ error });
-      const result: AppState = appReducer(initialAppState, action);
-
-      expect(result.error).toBe(error);
-    });
-
-    it('authenticated should set token', () => {
-      const token = 'some-token';
-      const action = AppActions.authenticated({ token });
-      const result: AppState = appReducer(initialAppState, action);
-
-      expect(result.token).toBe(token);
-    });
-  });
-
-  describe('unknown action', () => {
-    it('should return the previous state', () => {
-      const action = {} as any;
       const result = appReducer(initialAppState, action);
 
-      expect(result).toBe(initialAppState);
+      const expected: AppState = {
+        apiBaseUrl: '',
+        error: null,
+        loaded: false,
+        title: 'Email Sweeperr',
+      };
+
+      expect(result).toEqual(expected);
     });
   });
+
+  describe('[App/API] Load App Success action', () => {
+    it('should update the app state with the loaded app config', () => {
+      const action = AppActions.loadAppSuccess({
+        app: {
+          title: 'New Title',
+          apiBaseUrl: 'http://example.com',
+        },
+      });
+      const result = appReducer(initialAppState, action);
+
+      const expected: AppState = {
+        apiBaseUrl: 'http://example.com',
+        title: 'New Title',
+        loaded: true,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('[App/API] Load App Failure action', () => {
+    it('should update the app state with the error message', () => {
+      const action = AppActions.loadAppFailure({ error: 'An error occurred' });
+      const result = appReducer(initialAppState, action);
+
+      const expected: AppState = {
+        ...initialAppState,
+        error: 'An error occurred',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  // TODO: Add tests for authenticated action
+  // This action is not yet implemented beyond the PoC stage
 });

--- a/src/apps/ui/src/app/+state/app.reducer.ts
+++ b/src/apps/ui/src/app/+state/app.reducer.ts
@@ -15,6 +15,7 @@ export interface AppPartialState {
 }
 
 export const initialAppState: AppState = {
+  apiBaseUrl: '',
   title: 'Email Sweeperr',
 } as AppState;
 
@@ -23,6 +24,7 @@ const reducer = createReducer(
   on(AppActions.initApp, (state) => ({ ...state, loaded: false, error: null })),
   on(AppActions.loadAppSuccess, (state, { app }) => ({
     ...state,
+    apiBaseUrl: app.apiBaseUrl || state.apiBaseUrl,
     title: app.title || state.title,
     loaded: true,
   })),

--- a/src/apps/ui/src/app/+state/app.selectors.spec.ts
+++ b/src/apps/ui/src/app/+state/app.selectors.spec.ts
@@ -8,6 +8,7 @@ import { AppState } from './app.reducer';
 
 describe('App Selectors', () => {
   const initialState: AppState = {
+    apiBaseUrl: '',
     loaded: false,
     error: null,
     title: 'Test Title',

--- a/src/apps/ui/src/app/config/app-config.service.spec.ts
+++ b/src/apps/ui/src/app/config/app-config.service.spec.ts
@@ -1,54 +1,60 @@
 import { TestBed } from '@angular/core/testing';
-import {
-  HttpTestingController,
-  provideHttpClientTesting,
-} from '@angular/common/http/testing';
 import { AppConfigService } from './app-config.service';
 import { AppConfig } from './app-config';
-import { provideHttpClient } from '@angular/common/http';
+import { DOCUMENT } from '@angular/common';
 
 describe('AppConfigService', () => {
-  let service: AppConfigService;
-  let httpMock: HttpTestingController;
+  let doc: Document;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [],
-      providers: [
-        AppConfigService,
-        provideHttpClient(),
-        provideHttpClientTesting(),
-      ],
+      providers: [AppConfigService],
     });
-
-    service = TestBed.inject(AppConfigService);
-    httpMock = TestBed.inject(HttpTestingController);
+    doc = TestBed.inject(DOCUMENT);
   });
 
-  afterEach(() => {
-    httpMock.verify();
+  it('should be created', () => {
+    let service = TestBed.inject(AppConfigService);
+    expect(service).toBeTruthy();
   });
 
-  it('should return the app config', () => {
-    const mockConfig: AppConfig | undefined = {
-      apiBaseUrl: 'http://localhost:3000',
+  it('should return default config if window.EmailSweeper is not defined', () => {
+    const defaultConfig: AppConfig = {
+      title: 'Email Sweeper',
+      apiBaseUrl: '',
+      isFromDefault: true,
     };
-    service['appConfig'] = mockConfig;
+
+    let service = TestBed.inject(AppConfigService);
+    expect(service.config).toEqual(defaultConfig);
+  });
+
+  it('should return window.EmailSweeper config if defined', () => {
+    const mockConfig: AppConfig = {
+      title: 'Email Sweeper',
+      apiBaseUrl: 'http://example.com',
+      isFromDefault: false,
+    };
+    const win = doc.defaultView as any;
+    win.EmailSweeper = mockConfig;
+
+    // Reinitialize the service to pick up the new window.EmailSweeper value
+    let service = TestBed.inject(AppConfigService);
 
     expect(service.config).toEqual(mockConfig);
   });
 
-  it('should return an empty object if app config is not set', () => {
-    expect(service.config).toEqual({} as AppConfig);
-  });
-
-  it('should return true if config is loaded', () => {
-    service['appConfig'] = { apiBaseUrl: 'http://localhost:3000' };
+  it('should return true for isLoaded if config is defined', () => {
+    let service = TestBed.inject(AppConfigService);
     expect(service.isLoaded).toBeTruthy();
   });
 
-  it('should return false if config is not loaded', () => {
-    service['appConfig'] = undefined;
+  it('should return false for isLoaded if config is not defined', () => {
+    (window as any).EmailSweeper = undefined;
+    let service = TestBed.inject(AppConfigService);
+
+    // Reinitialize the service to pick up the new window.EmailSweeper value
+
     expect(service.isLoaded).toBeFalsy();
   });
 });

--- a/src/apps/ui/src/app/config/app-config.service.ts
+++ b/src/apps/ui/src/app/config/app-config.service.ts
@@ -1,40 +1,30 @@
-import { HttpClient } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
-import { catchError, map, Observable, of } from 'rxjs';
+import { inject, Inject, Injectable } from '@angular/core';
 import { AppConfig } from './app-config';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AppConfigService {
-  private readonly http = inject(HttpClient);
-  private appConfig: AppConfig | undefined;
+  private readonly appConfig: AppConfig;
+  @Inject(DOCUMENT) private readonly doc: any = inject(DOCUMENT);
 
-  loadAppConfig(): Observable<AppConfig> {
-    console.log('Loading app config...');
-    return this.http.get('/config.json').pipe(
-      map((data) => {
-        this.appConfig = data as AppConfig;
-        console.log('App config loaded:', this.appConfig);
-        return data as AppConfig;
-      }),
-      catchError((error) => {
-        console.error('Error loading app config:', error);
-        return of({} as AppConfig);
-      })
-    );
-
-    // for testing, lets just return a static object
-    // return of({
-    //   apiBaseUrl: 'http://localhost:3000',
-    // });
+  constructor() {
+    const win = this.doc.defaultView;
+    // Unit tests don't have access to the window object, so we need to provide a default value.
+    this.appConfig = (win?.EmailSweeper as AppConfig) ?? {
+      title: 'Email Sweeper',
+      apiBaseUrl: '',
+      isFromDefault: true,
+    };
   }
 
   get config(): AppConfig {
-    return this.appConfig || ({} as AppConfig);
+    return this.appConfig;
   }
 
   get isLoaded(): boolean {
-    return !!this.appConfig;
+    // The config should be loaded from the window object if it's not the default.
+    return !this.appConfig?.isFromDefault;
   }
 }

--- a/src/apps/ui/src/app/config/app-config.ts
+++ b/src/apps/ui/src/app/config/app-config.ts
@@ -1,1 +1,5 @@
-export interface AppConfig {}
+export interface AppConfig {
+  isFromDefault?: boolean;
+  apiBaseUrl: string;
+  title: string;
+}

--- a/src/apps/ui/src/index.html
+++ b/src/apps/ui/src/index.html
@@ -1,18 +1,27 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8" />
     <title>ui</title>
-    <base href="/"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
-      <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&amp;display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link rel="manifest" href="manifest.webmanifest">
-  <meta name="theme-color" content="#1976d2">
-</head>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <meta name="theme-color" content="#1976d2" />
+    <script src="/config.js"></script>
+  </head>
   <body class="mat-typography">
     <app-root></app-root>
-    <noscript>Please enable JavaScript to continue using this application.</noscript>
-</body>
+    <noscript
+      >Please enable JavaScript to continue using this application.</noscript
+    >
+  </body>
 </html>

--- a/src/apps/ui/src/main.ts
+++ b/src/apps/ui/src/main.ts
@@ -3,5 +3,5 @@ import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) =>
-  console.error(err),
+  console.error(err)
 );

--- a/src/apps/ui/src/server.ts
+++ b/src/apps/ui/src/server.ts
@@ -4,15 +4,17 @@ import express from 'express';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import bootstrap from './main.server';
+import { createProxyMiddleware } from 'http-proxy-middleware';
 
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
 const indexHtml = join(serverDistFolder, 'index.server.html');
 
 const app = express();
-app.disable("x-powered-by");
+app.disable('x-powered-by');
 const commonEngine = new CommonEngine();
 
+const apiUrl = process.env['API_URL'] ?? 'http://localhost:3000';
 /**
  * Example Express Rest API endpoints can be defined here.
  * Uncomment and define endpoints as necessary.
@@ -26,6 +28,17 @@ const commonEngine = new CommonEngine();
  */
 
 /**
+ * Proxy API requests
+ */
+app.use(
+  '/api',
+  createProxyMiddleware({
+    target: apiUrl,
+    changeOrigin: true,
+  })
+);
+
+/**
  * Serve static files from /browser
  */
 app.get(
@@ -33,7 +46,7 @@ app.get(
   express.static(browserDistFolder, {
     maxAge: '1y',
     index: 'index.html',
-  }),
+  })
 );
 
 /**


### PR DESCRIPTION
Fixes #38

Add `docker-compose.yaml` and `.env` files for multi-container setup.

* **docker-compose.yaml**
  - Define services for NestJS API, Angular client, and MongoDB.
  - Use image `ghcr.io/jtoniolo/email_sweeperr_api:dev` for NestJS API.
  - Use image `ghcr.io/jtoniolo/email_sweeperr_client:dev` for Angular client.
  - Use official MongoDB community image for MongoDB service.
  - Set dependencies: Angular client depends on NestJS API, NestJS API depends on MongoDB.
  - Set container names for each service using kabab-case and dev prefix.
  - Expose port 4200 for the Angular client service.

* **.env**
  - Add environment variables required to run the environment.
  - Include variables from `src/.env.example`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jtoniolo/email_sweeperr/pull/49?shareId=fef73494-706a-46c6-bd90-9e57aa0b9888).